### PR TITLE
change box colors

### DIFF
--- a/library/RAVE/src/RAVE/AppManager.py
+++ b/library/RAVE/src/RAVE/AppManager.py
@@ -158,22 +158,23 @@ class AppManager:
                 },
             )
 
-    def _update_selected_face(self, ident):
+    def _update_selected_face(self, payload):
         """
         Update the current selected face from the web client
         Args:
-            ident (id): Id of the face selected in the web client
+            payload (dict): Dictionary containing the id of the
+            face selected in the web client.
         """
-        self._selected_face = ident["targetId"]
+        self._selected_face = payload["targetId"]
         emit("selectedTarget", "client", {"targetID": self._selected_face})
 
     def _change_mode(self, payload):
         """
         Changes the vision mode when no faces are detected.
         Args:
-            payload (string):
-                Mode of the vision module when no faces are detected
-                ('mute' or 'hear').
+            payload (dict):
+                Dictionary containing Mode of the vision module
+                when no faces are detected('mute' or 'hear').
         """
         self._vision_mode = payload["mode"]
 

--- a/library/RAVE/src/RAVE/AppManager.py
+++ b/library/RAVE/src/RAVE/AppManager.py
@@ -6,8 +6,8 @@ import threading
 
 # from tqdm import tqdm
 
-from .face_detection.TrackingManager import TrackingManager
-from .face_detection.Pixel2Delay import Pixel2Delay
+from RAVE.face_detection.TrackingManager import TrackingManager
+from RAVE.face_detection.Pixel2Delay import Pixel2Delay
 
 
 sio = socketio.Client()
@@ -95,8 +95,10 @@ class AppManager:
         self._frame_output_frequency = 0.05
         self._delay_update_frequency = 0.25
         self._selected_face = None
+        self._vision_mode = "mute"
 
         sio.on("targetSelect", self._update_selected_face)
+        sio.on("changeVisionMode", self._change_mode)
 
     def start(self):
         """
@@ -162,7 +164,18 @@ class AppManager:
         Args:
             ident (id): Id of the face selected in the web client
         """
-        self._selected_face = ident
+        self._selected_face = ident["targetId"]
+        emit("selectedTarget", "client", {"targetID": self._selected_face})
+
+    def _change_mode(self, payload):
+        """
+        Changes the vision mode when no faces are detected.
+        Args:
+            payload (string):
+                Mode of the vision module when no faces are detected
+                ('mute' or 'hear').
+        """
+        self._vision_mode = payload["mode"]
 
     def _update_target_delays(self):
         """

--- a/rave-protocol/clientEvents.ts
+++ b/rave-protocol/clientEvents.ts
@@ -11,6 +11,7 @@ export enum CLIENT_EVENTS {
   CONNECTION_STATUS = 'connectionStatus',
   EYE_TRACKING_CONFIGURATIONS = 'configList',
   NEW_FRAME_AVAILABLE = 'newFrameAvailable',
+  SELECTED_TARGET = 'selectedTarget',
 };
 
 export interface BoundingBox {
@@ -92,5 +93,15 @@ export interface NewFrameAvailablePayload {
       dimensions,
       boundingBoxes,
     } as NewFrameAvailablePayload
+  }
+};
+
+export function selectedTargetEvent(targetID: number) {
+  return {
+    destination : MESSAGE_DESTINATIONS.CLIENT,
+    event : CLIENT_EVENTS.SELECTED_TARGET,
+    payload : {
+      targetID,
+    }
   }
 };

--- a/rave-protocol/pythonEvents.ts
+++ b/rave-protocol/pythonEvents.ts
@@ -8,6 +8,7 @@ interface AbstractPythonMessage extends AbstractMessage {
 export enum PYTHON_EVENTS {
   ACTIVATE_EYE_TRACKING = 'activateEyeTracking',
   CHANGE_VISION_CALIBRATION_PARAMS = 'changeCalibParams',
+  CHANGE_VISION_MODE = 'changeVisionMode',
   DELETE_CONFIG = 'deleteEyeTrackingCalib',
   EYE_TRACKER_ADD_NEW_CONFIG = 'addEyeTrackingCalib',
   EYE_TRACKING_CONFIG_SELECTED = 'selectEyeTrackingCalib',
@@ -88,6 +89,16 @@ export function ChangeVisionCalibrationParamsEvent(numberOfPoints : number, orde
       number : numberOfPoints,
       order : orderPolynomial,
     } as ChangeCalibrationParamsEvent
+  }
+};
+
+export function ChangeVisionModeEvent(visionMode: string) {
+  return {
+    destination : MESSAGE_DESTINATIONS.PYTHON,
+    event: PYTHON_EVENTS.CHANGE_VISION_MODE,
+    payload : {
+      mode : visionMode,
+    }
   }
 };
 

--- a/rave-web/src/Components/UI/CalibConfigs.tsx
+++ b/rave-web/src/Components/UI/CalibConfigs.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import AddCalibConfigs from "./AddCalibConfigs";
 import List from "@mui/material/List";
-import { DeleteIcon } from "../../Ressources/icons";
-import IconButton from "@mui/material/IconButton";
-import { ListItem } from "@mui/material";
+import { DeleteIcon, NoIcon, YesIcon } from "../../Ressources/icons";
+import { IconButton, Button } from "@mui/material";
+import { ListItem, Modal } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { useEventListener, useEmit } from "../../Hooks";
 import { CLIENT_EVENTS } from 'rave-protocol/clientEvents';
@@ -20,11 +20,15 @@ function CalibConfigs() {
     ptag && (ptag.innerHTML = name);
     emit(EyeTrackingConfigSelectedEvent(name));
   }
-
-  const deleteConfig = (name : string) => {
-    emit(DeleteConfigEvent(name));
+  const [open, setOpen] = useState(false);
+  const handleClose = () => setOpen(false);
+  const deleteConfig = () => {
+    setOpen(true);    
   }
-
+  const deleteClick = (name : string) => {
+    emit(DeleteConfigEvent(name));
+    setOpen(false);
+  }
   useEventListener(CLIENT_EVENTS.EYE_TRACKING_CONFIGURATIONS, ({configuration}) => {
     console.log("New configs");
     setConfigs(configuration);
@@ -45,9 +49,28 @@ function CalibConfigs() {
              sx={{hover: {fontWeight: "bold"}}}>
               <p className="hover:font-medium" onClick={() => handleSelect(item.name)}>{item.name}</p>  
               <div className=" absolute right-0 p-5">
-                <IconButton edge="end" aria-label="delete" onClick={() => deleteConfig(item.name)}>
+              <IconButton edge="end" aria-label="delete" onClick={deleteConfig}>
                 <DeleteIcon className={"w-5 h-5"}/>
               </IconButton>
+              <Modal
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="modal-delete-config"
+                aria-describedby="modal-delete-description"
+              >
+                <div className="flex flex-col w-fit place-items-center rounded shadow-lg p-2 bg-white absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2">
+                  <p className="font-black">{t('eyeTrackerCalibrationPage.deleteMessage')}</p>
+                  {item.name}
+                  <div className="flex flex-row">
+                    <Button sx={{ margin: '2px' }} onClick={() => setOpen(false)} variant="contained" color="error" size="small">
+                      <NoIcon className={"w-5 h-5"} />
+                    </Button>
+                    <Button sx={{ margin: '2px' }} onClick={() => deleteClick(item.name)} variant="contained" color="success" size="small">
+                      <YesIcon className={"w-5 h-5"} />
+                    </Button>
+                  </div>
+                </div>
+              </Modal>
               </div>
           </ListItem>)}
         </List>

--- a/rave-web/src/Components/UI/CalibConfigs.tsx
+++ b/rave-web/src/Components/UI/CalibConfigs.tsx
@@ -12,7 +12,7 @@ import { DeleteConfigEvent, EyeTrackingConfigSelectedEvent } from 'rave-protocol
 function CalibConfigs() {
   const [t] = useTranslation("common");
   const emit = useEmit();
-
+  const [nameDelete, setNameDelete] = useState<string>("");
   const [configs, setConfigs] = useState<{name : string}[]>([]);
   
   const handleSelect = (name : string) => {
@@ -22,8 +22,9 @@ function CalibConfigs() {
   }
   const [open, setOpen] = useState(false);
   const handleClose = () => setOpen(false);
-  const deleteConfig = () => {
-    setOpen(true);    
+  const deleteConfig = (name:string) => {
+    setOpen(true);
+    setNameDelete(name);    
   }
   const deleteClick = (name : string) => {
     emit(DeleteConfigEvent(name));
@@ -49,7 +50,7 @@ function CalibConfigs() {
              sx={{hover: {fontWeight: "bold"}}}>
               <p className="hover:font-medium" onClick={() => handleSelect(item.name)}>{item.name}</p>  
               <div className=" absolute right-0 p-5">
-              <IconButton edge="end" aria-label="delete" onClick={deleteConfig}>
+              <IconButton edge="end" aria-label="delete" onClick={() => deleteConfig(item.name)}>
                 <DeleteIcon className={"w-5 h-5"}/>
               </IconButton>
               <Modal
@@ -60,12 +61,12 @@ function CalibConfigs() {
               >
                 <div className="flex flex-col w-fit place-items-center rounded shadow-lg p-2 bg-white absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2">
                   <p className="font-black">{t('eyeTrackerCalibrationPage.deleteMessage')}</p>
-                  {item.name}
+                  {nameDelete}
                   <div className="flex flex-row">
                     <Button sx={{ margin: '2px' }} onClick={() => setOpen(false)} variant="contained" color="error" size="small">
                       <NoIcon className={"w-5 h-5"} />
                     </Button>
-                    <Button sx={{ margin: '2px' }} onClick={() => deleteClick(item.name)} variant="contained" color="success" size="small">
+                    <Button sx={{ margin: '2px' }} onClick={() => deleteClick(nameDelete)} variant="contained" color="success" size="small">
                       <YesIcon className={"w-5 h-5"} />
                     </Button>
                   </div>

--- a/rave-web/src/Components/UI/Stream.tsx
+++ b/rave-web/src/Components/UI/Stream.tsx
@@ -10,9 +10,20 @@ function Stream() {
   const roomCanvasRef = useRef<HTMLCanvasElement|null>(null);
   const emit = useEmit();
 
+  const [selectedTarget, setSelectedTarget] = useState<number>();
+  useEventListener(CLIENT_EVENTS.SELECTED_TARGET, ({targetID} : {targetID:number}) => {
+    setSelectedTarget(targetID);
+  });
+
   useEventListener(CLIENT_EVENTS.NEW_FRAME_AVAILABLE,(newFrame : NewFrameAvailablePayload) => {
     newFrame.boundingBoxes.forEach((box) => {
-      box.color = '#' + getRandomColor();
+      
+      if(box.id === selectedTarget){
+        box.color = "#0BB862"
+      }
+      else {
+        box.color = "#D32F2F"
+      }
     });
     setFrame(newFrame);
   });
@@ -53,8 +64,6 @@ function Stream() {
       }
     }
   }, [frame,debugging]);
-
-  const getRandomColor = () => Math.floor(Math.random() * 16777215).toString(16);
 
   return (
     <div className="container px-2">

--- a/rave-web/src/Components/UI/VisionModeSelection.tsx
+++ b/rave-web/src/Components/UI/VisionModeSelection.tsx
@@ -1,0 +1,40 @@
+import React, { FC, useState } from 'react';
+import Box from '@mui/material/Box';
+import { FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useEmit } from '../../Hooks/useEmit';
+import { ChangeVisionModeEvent } from 'rave-protocol';
+
+const VisionModeSelection : FC = () => {
+  const [t] = useTranslation('common');
+  const emit = useEmit();
+
+  const [visionMode, setVisionMode] = useState('mute');
+  const handleChange= (event: SelectChangeEvent<string>) => {
+    emit(ChangeVisionModeEvent(event.target.value));
+    setVisionMode(event.target.value);
+  }
+  return (
+    <div className='pb-4 mx-4 w-3/4'>
+      <Box sx={{ minWidth: 120 }}>
+        <FormControl fullWidth color="error">
+          <InputLabel color='error' id="vision-mode-selection-label">
+            {t("settingsPage.visionMode.label")}
+          </InputLabel>
+          <Select
+            labelId='vision-mode-select-label'
+            id='vision-mode-select'
+            value={visionMode}
+            label='Vision Mode'
+            onChange={handleChange}
+          >
+            <MenuItem value={'mute'}>{t('settingsPage.visionMode.muteMode')}</MenuItem>
+            <MenuItem value={'hear'}>{t('settingsPage.visionMode.hearMode')}</MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+    </div>
+  );
+}
+
+export default VisionModeSelection;

--- a/rave-web/src/Hooks/useEventListener.ts
+++ b/rave-web/src/Hooks/useEventListener.ts
@@ -8,23 +8,20 @@ export type WsFunctionHandler = {
 
 
 export function useEventListener(event: CLIENT_EVENTS, handler : WsFunctionHandler){
-  // Prevents refresh on parent component refresh
-  const [handlerFunction,] = useState(() => handler);
   const [cleanUpFunction, setCleanUpFunction] = useState<Function | null>(null);
   const ws = useContext(SocketContext);
 
   useEffect(()=> {
     if(ws?.connected){
       ws.on(event,(payload) => {
-        if(handlerFunction instanceof Function){
-          const cleanup = handlerFunction(payload);
-          cleanup && cleanup !== cleanUpFunction && setCleanUpFunction(cleanup);
-        }
+        const cleanup = handler(payload);
+        cleanup && cleanup !== cleanUpFunction && setCleanUpFunction(cleanup);
       });
     }
     return () => {
       ws?.removeAllListeners(event);
       cleanUpFunction && cleanUpFunction();
     }
-  },[cleanUpFunction, event, handlerFunction, ws]);
+  },[cleanUpFunction, event, handler, ws]);
+
 }

--- a/rave-web/src/Ressources/icons.js
+++ b/rave-web/src/Ressources/icons.js
@@ -167,3 +167,25 @@ export function SaveIcon(props) {
 </svg>
   );
 }
+
+YesIcon.propTypes = {
+  className: PropTypes.string,
+}
+export function YesIcon(props) {
+  return (
+    <svg className={props.className} viewBox="0 0 24 24">
+      <path fill="currentColor" d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z" />
+    </svg>
+  );
+}
+
+NoIcon.propTypes = {
+  className: PropTypes.string,
+}
+export function NoIcon(props) {
+  return (
+    <svg className={props.className} viewBox="0 0 24 24">
+      <path fill="currentColor" d="M20 6.91L17.09 4L12 9.09L6.91 4L4 6.91L9.09 12L4 17.09L6.91 20L12 14.91L17.09 20L20 17.09L14.91 12L20 6.91Z" />
+    </svg>
+  );
+}

--- a/rave-web/src/Screens/Settings/Settings.tsx
+++ b/rave-web/src/Screens/Settings/Settings.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import React, { useContext } from "react";
 import Switch from '@mui/material/Switch';
 import { DebugContext } from "../../DebugContextProvider";
+import VisionModeSelection from "../../Components/UI/VisionModeSelection";
 
 function SettingsScreen() {
   const [t] = useTranslation('common');
@@ -14,6 +15,7 @@ function SettingsScreen() {
     <div className="flex flex-col items-center">
       <h1 className="text-3xl font-bold underline text-center">{t('settingsPage.title')}</h1>
       <LanguageSelection className={"py-4 mx-4 w-3/4"}/>
+      <VisionModeSelection />
       <ConnectionStatus/>
       <Link 
         to={`/calibration`}

--- a/rave-web/src/translations/en/common.js
+++ b/rave-web/src/translations/en/common.js
@@ -12,6 +12,11 @@ const common = {
       french: 'French',
       english: 'English',
     },
+    visionMode: {
+      label: 'Vision Mode',
+      muteMode: "Mute All",
+      hearMode: 'Hear All',
+    },
     connectionLabel: 'Connection Status:',
     visionCalibration: 'Audio-Visual Calibration',
     eyeTrackerCalibration: 'Eye-Tracker Calibration',
@@ -48,6 +53,7 @@ const common = {
     configName: 'Name',
     configPlaceholder: 'Enter your full name',
     errorMessage: 'The name you have chosen alreay exists, choose another one.',
+    deleteMessage: 'Are you sure you want to delete this calibration?',
   }
 };
 export default common;

--- a/rave-web/src/translations/fr/common.js
+++ b/rave-web/src/translations/fr/common.js
@@ -12,10 +12,15 @@ const common = {
       french: 'Français',
       english: 'Anglais',
     },
+    visionMode: {
+      label: 'Mode de vision',
+      muteMode: "Tout en sourdine",
+      hearMode: 'Tout entendre',
+    },
     connectionLabel: 'État de la connexion:',
     visionCalibration: 'Calibration audio-visuelle',
     eyeTrackerCalibration: 'Calibration eye-tracker',
-    debugMode: 'Mode debuggage',
+    debugMode: 'Mode débogage',
   },
   helpPage: {
     title: 'Aide',
@@ -48,6 +53,7 @@ const common = {
     configName: 'Nom',
     configPlaceholder: 'Entrer votre nom complet',
     errorMessage: 'Le nom que vous avez choisi existe déjà, choisir un nouveau.',
+    deleteMessage: 'Êtes-vous sûr de vouloir supprimer cette calibration?',
   }
 };
 export default common;


### PR DESCRIPTION
Changed the bounding box colors to red and green when selected.
Python sends the selected target id to the website.

Also added the vision mode in python with a component in settings page of website to change between the 2 modes (mute or hear).
Also added a confirm pop up when trying to delete an eye tracking calibration configuration.